### PR TITLE
Validate attached DHCP Options Sets

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func main() {
 
 	if err := mirrosa.ValidateComponents(context.TODO(),
 		mirrosa.NewVpc(),
+		mirrosa.NewDhcpOptions(),
 		mirrosa.NewSecurityGroup(),
 		mirrosa.NewVpcEndpointService(),
 		mirrosa.NewPublicHostedZone(),

--- a/pkg/mirrosa/dhcp_options.go
+++ b/pkg/mirrosa/dhcp_options.go
@@ -1,0 +1,87 @@
+package mirrosa
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"go.uber.org/zap"
+)
+
+const dhcpOptionsDescription = "A ROSA cluster's DHCP Options Set must not have uppercase letters in its domain-name" +
+	" due to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names."
+
+// Ensure DhcpOptions implements Component
+var _ Component = &DhcpOptions{}
+
+type MirrosaDhcpOptionsAPIClient interface {
+	ec2.DescribeDhcpOptionsAPIClient
+	ec2.DescribeVpcsAPIClient
+}
+
+type DhcpOptions struct {
+	log   *zap.SugaredLogger
+	VpcId string
+
+	Ec2Client MirrosaDhcpOptionsAPIClient
+}
+
+func (c *Client) NewDhcpOptions() DhcpOptions {
+	return DhcpOptions{
+		log:       c.log,
+		VpcId:     c.ClusterInfo.VpcId,
+		Ec2Client: ec2.NewFromConfig(c.AwsConfig),
+	}
+}
+
+func (d DhcpOptions) Validate(ctx context.Context) error {
+	d.log.Debugf("validating that the attached DHCP Options Set has no uppercase characters in its domain name(s)")
+	vpcResp, err := d.Ec2Client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+		VpcIds: []string{d.VpcId},
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(vpcResp.Vpcs) != 1 {
+		return fmt.Errorf("unexpectedly received %d VPCs when describing: %s", len(vpcResp.Vpcs), d.VpcId)
+	}
+	dhcpOptionsId := *vpcResp.Vpcs[0].DhcpOptionsId
+
+	dhcpResp, err := d.Ec2Client.DescribeDhcpOptions(ctx, &ec2.DescribeDhcpOptionsInput{
+		DhcpOptionsIds: []string{dhcpOptionsId},
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(dhcpResp.DhcpOptions) != 1 {
+		return fmt.Errorf("unexepctedly received %d DHCP Options Sets when describing: %s", len(dhcpResp.DhcpOptions), dhcpOptionsId)
+	}
+
+	for _, config := range dhcpResp.DhcpOptions[0].DhcpConfigurations {
+		switch *config.Key {
+		case "domain-name":
+			for _, v := range config.Values {
+				d.log.Debugf("validating DHCP Options Set domain name: %s", *v.Value)
+				if *v.Value != strings.ToLower(*v.Value) {
+					return fmt.Errorf("DHCP Options set: %s contains uppercase letters in the domain name: %s", dhcpOptionsId, *v.Value)
+				}
+			}
+		default:
+			// Other DHCP Options set configurations have no hard rules
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (d DhcpOptions) Documentation() string {
+	return dhcpOptionsDescription
+}
+
+func (d DhcpOptions) FilterValue() string {
+	return "DHCP Options"
+}

--- a/pkg/mirrosa/dhcp_options_test.go
+++ b/pkg/mirrosa/dhcp_options_test.go
@@ -1,0 +1,120 @@
+package mirrosa
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"go.uber.org/zap/zaptest"
+	"testing"
+)
+
+type mockMirrosaDhcpOptionsAPIClient struct {
+	describeDhcpOptionsResp *ec2.DescribeDhcpOptionsOutput
+	describeVpcsResp        *ec2.DescribeVpcsOutput
+}
+
+func (m mockMirrosaDhcpOptionsAPIClient) DescribeVpcs(ctx context.Context, params *ec2.DescribeVpcsInput, optFns ...func(options *ec2.Options)) (*ec2.DescribeVpcsOutput, error) {
+	return m.describeVpcsResp, nil
+}
+
+func (m mockMirrosaDhcpOptionsAPIClient) DescribeDhcpOptions(ctx context.Context, params *ec2.DescribeDhcpOptionsInput, optFns ...func(options *ec2.Options)) (*ec2.DescribeDhcpOptionsOutput, error) {
+	return m.describeDhcpOptionsResp, nil
+}
+
+func TestDhcpOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		dhcpOptions *DhcpOptions
+		expectErr   bool
+	}{
+		{
+			name: "all lowercase",
+			dhcpOptions: &DhcpOptions{
+				log:   zaptest.NewLogger(t).Sugar(),
+				VpcId: "id",
+				Ec2Client: &mockMirrosaDhcpOptionsAPIClient{
+					describeDhcpOptionsResp: &ec2.DescribeDhcpOptionsOutput{
+						DhcpOptions: []types.DhcpOptions{
+							{
+								DhcpConfigurations: []types.DhcpConfiguration{
+									{
+										Key: aws.String("domain-name"),
+										Values: []types.AttributeValue{
+											{
+												Value: aws.String("ec2.internal"),
+											},
+										},
+									},
+								},
+								DhcpOptionsId: aws.String("dhcp-id"),
+							},
+						},
+					},
+					describeVpcsResp: &ec2.DescribeVpcsOutput{
+						Vpcs: []types.Vpc{
+							{
+								DhcpOptionsId: aws.String("dhcp-id"),
+								VpcId:         aws.String("id"),
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "contains uppercase",
+			dhcpOptions: &DhcpOptions{
+				log:   zaptest.NewLogger(t).Sugar(),
+				VpcId: "id",
+				Ec2Client: &mockMirrosaDhcpOptionsAPIClient{
+					describeDhcpOptionsResp: &ec2.DescribeDhcpOptionsOutput{
+						DhcpOptions: []types.DhcpOptions{
+							{
+								DhcpConfigurations: []types.DhcpConfiguration{
+									{
+										Key: aws.String("domain-name"),
+										Values: []types.AttributeValue{
+											{
+												Value: aws.String("ec2.internal"),
+											},
+											{
+												Value: aws.String("My.cUsTom.DoMaIn"),
+											},
+										},
+									},
+								},
+								DhcpOptionsId: aws.String("dhcp-id"),
+							},
+						},
+					},
+					describeVpcsResp: &ec2.DescribeVpcsOutput{
+						Vpcs: []types.Vpc{
+							{
+								DhcpOptionsId: aws.String("dhcp-id"),
+								VpcId:         aws.String("id"),
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.dhcpOptions.Validate(context.TODO())
+			if err != nil {
+				if !test.expectErr {
+					t.Errorf("expected no err, got %v", err)
+				}
+			} else {
+				if test.expectErr {
+					t.Error("expected err, got nil")
+				}
+			}
+		})
+	}
+}

--- a/pkg/mirrosa/vpc.go
+++ b/pkg/mirrosa/vpc.go
@@ -48,7 +48,6 @@ func (v Vpc) Validate(ctx context.Context) error {
 		return err
 	}
 
-	// Make sure dnsHostname's enableDnsHostnames attribute is true
 	if !*dnsHostnames.EnableDnsHostnames.Value {
 		return fmt.Errorf("enableDnsHostnames is false for VPC: %s", v.Id)
 	}
@@ -62,7 +61,6 @@ func (v Vpc) Validate(ctx context.Context) error {
 		return err
 	}
 
-	// Repeat for enableDnsSupport
 	if !*dnsSupport.EnableDnsSupport.Value {
 		return fmt.Errorf("enableDnsSupport is false for VPC: %s", v.Id)
 	}


### PR DESCRIPTION
AWS allows for uppercase letters in DHCP Options Set domain names, however this is not valid in Kubernetes/ROSA as it gets cast to all lowercase due to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names, which causes a CSR mismatch and nodes fail to join the cluster.