### PR TITLE
Remove mention of old backplane-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ cosign verify-blob --key signing.pub --signature mirrosa_darwin_arm64.sig mirros
 ## Developer Installation
 
 ```bash
-go install github.com/mjlshen/mirrosa
+go install github.com/mjlshen/mirrosa@latest
 ```
 
 ## Prerequisites
 
 - Valid OCM session
-- Active OCM backplane tunnel (`ocm backplane tunnel -D`)
+- [backplane-cli](https://github.com/openshift/backplane-cli) with the right configuration.
 
 ## Usage
 


### PR DESCRIPTION
With the release of the new [backplane-cli](https://github.com/openshift/backplane-cli), we no longer need tunnels.
This PR aims to correct the documentation concerning the same.

**Note:** I really like this tool and turned out pretty handy while on my oncall shift. Would love to contribute to the TUI aspects of it if needed as I have a bit of prior experience working on [kite](https://github.com/openshift/pagerduty-short-circuiter).